### PR TITLE
Update ruby version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.2.5
+  - 2.3.2
 script: bundle exec rake travis


### PR DESCRIPTION
A few gems the cookbook depends on aren't supporting ruby 1.9 and 2.0, so I updated the travis.yml with more recent ruby versions 